### PR TITLE
Enable 1.4 features and research

### DIFF
--- a/Defs/ThingDefs_Buildings/CeilingLight.xml
+++ b/Defs/ThingDefs_Buildings/CeilingLight.xml
@@ -30,10 +30,18 @@
             <li Class="CompProperties_Power">
                 <compClass>CompPowerTrader</compClass>
                 <basePowerConsumption>20</basePowerConsumption>
+                <powerUpgrades>
+                    <li>
+                        <researchProject>ColoredLights</researchProject>
+                        <factor>0.5</factor>
+                    </li>
+                </powerUpgrades>
             </li>
             <li Class="CompProperties_Glower">
                 <glowRadius>30</glowRadius>
                 <glowColor>(217,217,208,0)</glowColor>
+                <colorPickerEnabled>true</colorPickerEnabled>
+                <darklightToggle>true</darklightToggle>
             </li>
         </comps>
         <rotatable>false</rotatable>


### PR DESCRIPTION
* Enable the Color picker
* Enable Darklight swap
* When Advanced Lighting researched cut the power consumption to half. In line with vanilla standing lamps.